### PR TITLE
Configure federation

### DIFF
--- a/backend/services.yml
+++ b/backend/services.yml
@@ -40,3 +40,16 @@ services:
       retries: 5
       start_period: 40s
 
+  seeder:
+    image: node:20-alpine
+    working_dir: /job
+    volumes:
+      - ../common/seeder/.:/job/.
+    command: sh -c "npm i && npm run seed"
+    environment:
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=http://sublinks:8080
+    logging: *default-logging
+    depends_on:
+      sublinks:
+        condition: service_healthy
+

--- a/common/proxy.yml
+++ b/common/proxy.yml
@@ -1,0 +1,32 @@
+version: "3.7"
+
+volumes:
+  letsencrypt:
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "4"
+
+services:
+  proxy:
+    image: jonasal/nginx-certbot:4.3.0-nginx1.25.1-alpine
+    environment:
+      CERTBOT_EMAIL: developer@example.com
+      USE_LOCAL_CA: 1
+      STAGING: 1
+      NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE: 1
+    ports:
+      - "80:8080"
+      - "443:8443"
+    volumes:
+      - ./nginx/nginx_internal.conf:/etc/nginx/user_conf.d/nginx.conf:ro,Z
+      - ./nginx/proxy_params:/etc/nginx/proxy_params:ro,Z
+      - letsencrypt:/etc/letsencrypt
+    restart: always
+    logging: *default-logging
+    depends_on:
+      ui:
+        condition: service_healthy
+

--- a/common/services.yml
+++ b/common/services.yml
@@ -10,26 +10,6 @@ x-logging: &default-logging
     max-file: "4"
 
 services:
-  proxy:
-    image: jonasal/nginx-certbot:4.3.0-nginx1.25.1-alpine
-    environment:
-      CERTBOT_EMAIL: developer@example.com
-      USE_LOCAL_CA: 1
-      STAGING: 1
-      NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE: 1
-    ports:
-      - "80:8080"
-      - "443:8443"
-    volumes:
-      - ./nginx/nginx_internal.conf:/etc/nginx/user_conf.d/nginx.conf:ro,Z
-      - ./nginx/proxy_params:/etc/nginx/proxy_params:ro,Z
-      - letsencrypt:/etc/letsencrypt
-    restart: always
-    logging: *default-logging
-    depends_on:
-      ui:
-        condition: service_healthy
-
   maindb:
     image: mysql:latest
     environment:

--- a/common/services.yml
+++ b/common/services.yml
@@ -76,16 +76,3 @@ services:
       retries: 5
       start_period: 30s
 
-  seeder:
-    image: node:20-alpine
-    working_dir: /job
-    volumes:
-      - ./seeder/.:/job/.
-    command: sh -c "npm i && npm run seed"
-    environment:
-      - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=http://sublinks:8080
-    logging: *default-logging
-    depends_on:
-      sublinks:
-        condition: service_healthy
-

--- a/docker-compose.federation.yml
+++ b/docker-compose.federation.yml
@@ -1,0 +1,6 @@
+version: "3.7"
+
+include:
+  - common/services.yml
+  - backend/services.yml
+

--- a/frontend/services.yml
+++ b/frontend/services.yml
@@ -6,6 +6,9 @@ x-logging: &default-logging
     max-size: "50m"
     max-file: "4"
 
+include:
+  - common/proxy.yml
+
 services:
   ui:
     image: node:20-alpine

--- a/lemmy-ui/services.yml
+++ b/lemmy-ui/services.yml
@@ -6,6 +6,9 @@ x-logging: &default-logging
     max-size: "50m"
     max-file: "4"
 
+include:
+  - common/proxy.yml
+
 services:
   ui:
     image: dessalines/lemmy-ui:0.19.3


### PR DESCRIPTION
## Summary of changes

- Moved seeder config to backend/services.yml because it is dependant on API service and not necessarily a "common" service
- Moved proxy service to its own config file as not all services need it for local dev (eg, federation does not always need it. Same with backend. There are times we will want it, but we don't always need it running)
- Added a docker-compose file for running dependency services for federation service

## Reason for tagging of so many people for approvals
### Frontend team
- frontend/services.yml was touched to reference the new proxy config file
### Backend team
- backend/services.yml was touched to reference seeder (see above)
### Federation team
- Well.. I mean, the point of this PR is for the federation team so... 😄 
### Core Developers
- Sorry (not sorry), you get pinged on all PRs for this repo 😜