### PR TITLE
Change API docker image to use 'main' tag

### DIFF
--- a/backend/services.yml
+++ b/backend/services.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   sublinks:
-    image: ghcr.io/sublinks/sublinks-api:0.0.1-snapshot
+    image: ghcr.io/sublinks/sublinks-api:main
     restart: always
     environment:
       SUBLINKS_DB_URL: jdbc:mysql://maindb:3306/backend


### PR DESCRIPTION
After the merge of https://github.com/sublinks/sublinks-api/pull/265 the tag being published for the API image changed from `0.0.1-SNAPSHOT` to `main` (NOTE: releases will use tags, but nightly build will now be the name of the branch)