### PR TITLE
Proxy common path fix

### DIFF
--- a/frontend/services.yml
+++ b/frontend/services.yml
@@ -7,7 +7,7 @@ x-logging: &default-logging
     max-file: "4"
 
 include:
-  - common/proxy.yml
+  - ../common/proxy.yml
 
 services:
   ui:

--- a/lemmy-ui/services.yml
+++ b/lemmy-ui/services.yml
@@ -7,7 +7,7 @@ x-logging: &default-logging
     max-file: "4"
 
 include:
-  - common/proxy.yml
+  - ../common/proxy.yml
 
 services:
   ui:


### PR DESCRIPTION
Noticed when trying to run frontend service that it couldn't find the proxy.yml file. Need to have it look in the parent dir.