### PR TITLE
Frontend service browser API requests

### DIFF
--- a/common/nginx/nginx_internal.conf
+++ b/common/nginx/nginx_internal.conf
@@ -1,9 +1,7 @@
-map "$request_method:$http_accept" $proxpass {
-    default "http://ui:3000";
-
-    "~^(?:GET|HEAD):.*?application\/(?:activity|ld)\+json" "http://federation:8080";
-
-    "~^(?!(GET|HEAD)).*:" "http://sublinks:8080";
+map $http_accept $proxpass {
+    "~application\/json"                      http://federation:8080;
+    "~application\/(activity\+json|ld\+json)" http://federation:8080;
+    default                                   http://ui:3000;
 }
 
 limit_req_zone $binary_remote_addr zone=limiter:10m rate=100r/s;

--- a/common/nginx/nginx_internal.conf
+++ b/common/nginx/nginx_internal.conf
@@ -47,12 +47,12 @@ server {
         include proxy_params;
     }
 
-      # rate limit on /api/v3 endpoints
-      location ~ ^/api/v3/(post|message|register|image|comment|search) {
-          limit_req zone=limiter burst=5 nodelay;
-          proxy_pass "http://sublinks:8080";
-          include proxy_params;
-      }
+    # rate limit on /api/v3 endpoints
+    location ~ ^/api/v3/(post|message|register|image|comment|search) {
+        limit_req zone=limiter burst=5 nodelay;
+        proxy_pass "http://sublinks:8080";
+        include proxy_params;
+    }
 }
 server {
     listen 8443 ssl;

--- a/common/nginx/nginx_internal.conf
+++ b/common/nginx/nginx_internal.conf
@@ -28,6 +28,8 @@ server {
     location / {
         limit_req zone=limiter burst=50;
         proxy_pass $proxpass;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         rewrite ^(.+)/+$ $1 permanent;
     }
 
@@ -79,6 +81,8 @@ server {
     # frontend general requests
     location / {
         proxy_pass $proxpass;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         rewrite ^(.+)/+$ $1 permanent;
     }
 

--- a/common/nginx/nginx_internal.conf
+++ b/common/nginx/nginx_internal.conf
@@ -6,7 +6,7 @@ map "$request_method:$http_accept" $proxpass {
     "~^(?!(GET|HEAD)).*:" "http://sublinks:8080";
 }
 
-limit_req_zone $binary_remote_addr zone=limiter:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=limiter:10m rate=100r/s;
 
 server {
     # this is the port inside docker, not the public one yet
@@ -28,7 +28,7 @@ server {
 
     # frontend general requests
     location / {
-        limit_req zone=limiter burst=5;
+        limit_req zone=limiter burst=50;
         proxy_pass $proxpass;
         rewrite ^(.+)/+$ $1 permanent;
     }
@@ -40,7 +40,7 @@ server {
 
     # backend
     location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
-        limit_req zone=limiter burst=5;
+        limit_req zone=limiter burst=50;
         proxy_pass "http://sublinks:8080";
 
         # Send actual client IP upstream
@@ -49,7 +49,7 @@ server {
 
     # rate limit on /api/v3 endpoints
     location ~ ^/api/v3/(post|message|register|image|comment|search) {
-        limit_req zone=limiter burst=5 nodelay;
+        limit_req zone=limiter burst=50 nodelay;
         proxy_pass "http://sublinks:8080";
         include proxy_params;
     }

--- a/federation/services.yml
+++ b/federation/services.yml
@@ -13,7 +13,8 @@ services:
     environment:
       DB_DSN: "federation:federation@tcp(maindb:3306)/federation?charset=utf8mb4&parseTime=True&loc=Local"
       AMQP_SERVER_URL: "amqp://sublinks:sublinks@queue:5672"
-      HOSTNAME: sublinks.org"
+      HOSTNAME: sublinks.org
+      LISTEN_ADDR: ":8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/"]
       interval: 15s

--- a/frontend/services.yml
+++ b/frontend/services.yml
@@ -34,5 +34,7 @@ services:
     depends_on:
       sublinks:
         condition: service_healthy
+      federation:
+        condition: service_healthy
     logging: *default-logging
 

--- a/frontend/services.yml
+++ b/frontend/services.yml
@@ -19,7 +19,7 @@ services:
     command: sh -c "npm i && npm run dev"
     environment:
       - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=sublinks:8080
-      - NEXT_PUBLIC_SUBLINKS_API_BASE_PUBLIC_URL=localhost:3000
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_PUBLIC_URL=localhost
       - NEXT_PUBLIC_HTTPS_ENABLED=false
       - WATCHPACK_POLLING=true
     restart: always

--- a/frontend/services.yml
+++ b/frontend/services.yml
@@ -19,6 +19,8 @@ services:
     command: sh -c "npm i && npm run dev"
     environment:
       - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=sublinks:8080
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_PUBLIC_URL=localhost:3000
+      - NEXT_PUBLIC_HTTPS_ENABLED=false
       - WATCHPACK_POLLING=true
     restart: always
     healthcheck:


### PR DESCRIPTION
First step is adding the newly expected env vars.

Current problem is that when the Sublinks UI service attempts to call http://localhost:3000/ for an API request in the browser, it's receiving a 404 response.

> It looks like the 3000 port was changed from the proxy to the ui service. Compared to the docker compose setup we have in the frontend today. I'm not familiar enough with nginx to say what the problem is. But I assume it's something with the proxy.