### PR TITLE
Support sublinksui for demo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @sublinks/core-developers
 frontend/ @sublinks/sublinks-frontend-service @sublinks/core-developers 
+sublinks-ui/ @sublinks/sublinks-frontend-service @sublinks/core-developers 
 common/seeder/ @sublinks/sublinks-frontend-service @sublinks/core-developers 
 docker-compose.frontend.yml @sublinks/sublinks-frontend-service @sublinks/core-developers 
 federation/ @sublinks/sublinks-federation-service @sublinks/core-developers

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ containers they are brought up in a "clean" state)
 ## Demo Site
 
 Run `docker-compose -f docker-compose.demo.yml up [-d]`
+OR to run the demo site with the Sublinks UI (currently experimental), run:
+`UI=sublinks docker-compose -f docker-compose.demo.yml up [-d]`
 
 ## Frontend Dev
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,42 @@
 # Sublinks Docker
 
-This repo will hold docker-compose.yml files to run Sublinks for demo/live as well as local dev purposes
+This repo will hold docker-compose.yml files to run Sublinks for demo/live
+as well as local dev purposes
 
-***CURRENT STATUS: Please note, this repo currently holds configuration files intended for development purposes only. As we get closer to our initial MVP release we will provide sample files for use in a live site.***
+***CURRENT STATUS: Please note, this repo currently holds configuration files
+intended for development purposes only. As we get closer to our initial MVP
+release we will provide sample files for use in a live site.***
 
 ## Preface
 
-[] surrounding a paramter indicates the parameter is optional. The brackets themselves should not be included. Eg:
+[] surrounding a paramter indicates the parameter is optional. The brackets
+themselves should not be included. Eg:
 
-```
+```bash
 docker-compose -f docker-compose.demo.yml up [-d]
 ```
 
 In the above command, you can run it either as:
 
-```
+```bash
 docker-compose -f docker-compose.demo.yml up
 ```
 
 or
 
-```
+```bash
 docker-compose -f docker-compose.demo.yml up -d
 ```
 
-The `-d` is optional. It means "detach" and will cause the command prompt to return almost immediately but the docker images will continue running in the background.  If you use this method, you must run `docker-compose -f docker-compose.demo.yml down` in order to teardown the environment (NOTE: You can also use `stop` instead of `down` if you only want to stop the containers but not actually tear them down. This is useful if you plan to bring the containers back up and want their current state to be remembered. Otherwise, `down` will ensure the next time you launch the containers they are brought up in a "clean" state)
+The `-d` is optional. It means "detach" and will cause the command prompt to
+return almost immediately but the docker images will continue running in the
+background.  If you use this method, you must run
+`docker-compose -f docker-compose.demo.yml down` in order to teardown the
+environment (NOTE: You can also use `stop` instead of `down` if you only want
+to stop the containers but not actually tear them down. This is useful if you
+plan to bring the containers back up and want their current state to be
+remembered. Otherwise, `down` will ensure the next time you launch the
+containers they are brought up in a "clean" state)
 
 ## Demo Site
 
@@ -41,4 +53,3 @@ Run `docker-compose -f docker-compose.backend.yml up [-d]`
 ## Federation Dev
 
 Run `docker-compose -f docker-compose.federation.yml up [-d]`
-

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -4,5 +4,5 @@ include:
   - common/services.yml
   - backend/services.yml
   - federation/services.yml
-  - lemmy-ui/services.yml
+  - ${UI:-lemmy}-ui/services.yml
 

--- a/sublinks-ui/services.yml
+++ b/sublinks-ui/services.yml
@@ -1,0 +1,32 @@
+version: "3.7"
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "4"
+
+include:
+  - ../common/proxy.yml
+
+services:
+  ui:
+    image: ghcr.io/sublinks/sublinks-frontend:main
+    environment:
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=sublinks:8080
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_PUBLIC_URL=demo.sublinks.org
+      - NEXT_PUBLIC_HTTPS_ENABLED=true
+    restart: always
+    logging: *default-logging
+    depends_on:
+      sublinks:
+        condition: service_healthy
+      federation:
+        condition: service_healthy
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+      start_period: 10s
+      interval: 30s
+      timeout: 60s
+      retries: 3
+


### PR DESCRIPTION
Add support for choosing which UI to run the demo site under (Lemmy or Sublinks). Currently defaults to Lemmy UI since Sublinks UI is still under active development and not ready to be used for demo purposes.

~NOTE: This requires https://github.com/sublinks/sublinks-frontend/pull/112 to be merged first.~ (Done)