### PR TITLE
Add Backend Configurations for Local API Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Run `docker-compose -f docker-compose.frontend.yml up [-d]`
 ## Backend Dev
 
 Run `docker-compose -f docker-compose.backend.yml up [-d]`
+OR to run the Sublinks UI (currently experimental), run:
+`UI=sublinks docker-compose -f docker-compose.backend.yml up [-d]`
 
 ## Federation Dev
 

--- a/backend/seeder.yml
+++ b/backend/seeder.yml
@@ -14,8 +14,10 @@ services:
       - ../common/seeder/.:/job/.
     command: sh -c "npm i && npm run seed"
     environment:
-      - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=http://sublinks:8080
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=http://${API_HOST:-sublinks}:8080
     logging: *default-logging
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       api:
         condition: service_healthy

--- a/backend/seeder.yml
+++ b/backend/seeder.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "4"
+
+services:
+  seeder:
+    image: node:20-alpine
+    working_dir: /job
+    volumes:
+      - ../common/seeder/.:/job/.
+    command: sh -c "npm i && npm run seed"
+    environment:
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=http://sublinks:8080
+    logging: *default-logging
+    depends_on:
+      api:
+        condition: service_healthy

--- a/backend/services.yml
+++ b/backend/services.yml
@@ -6,6 +6,9 @@ x-logging: &default-logging
     max-size: "50m"
     max-file: "4"
 
+include:
+  - seeder.yml
+
 services:
   api:
     image: ghcr.io/sublinks/sublinks-api:main
@@ -39,17 +42,3 @@ services:
       timeout: 5s
       retries: 5
       start_period: 40s
-
-  seeder:
-    image: node:20-alpine
-    working_dir: /job
-    volumes:
-      - ../common/seeder/.:/job/.
-    command: sh -c "npm i && npm run seed"
-    environment:
-      - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=http://sublinks:8080
-    logging: *default-logging
-    depends_on:
-      api:
-        condition: service_healthy
-

--- a/backend/services.yml
+++ b/backend/services.yml
@@ -7,7 +7,7 @@ x-logging: &default-logging
     max-file: "4"
 
 services:
-  sublinks:
+  api:
     image: ghcr.io/sublinks/sublinks-api:main
     restart: always
     environment:
@@ -50,6 +50,6 @@ services:
       - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=http://sublinks:8080
     logging: *default-logging
     depends_on:
-      sublinks:
+      api:
         condition: service_healthy
 

--- a/common/nginx/Dockerfile
+++ b/common/nginx/Dockerfile
@@ -1,0 +1,11 @@
+FROM jonasal/nginx-certbot:4.3.0-nginx1.25.1-alpine
+
+# Copy nginx configuration file and startup script
+COPY api_proxy /tmp/api_proxy
+COPY start.sh /usr/local/bin/start.sh
+
+# Set execute permissions for the startup script
+RUN chmod +x /usr/local/bin/start.sh
+
+# Set the startup script as the entry point
+ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/common/nginx/api_proxy
+++ b/common/nginx/api_proxy
@@ -1,0 +1,1 @@
+proxy_pass "http://${API_HOST}:8080";

--- a/common/nginx/nginx_internal.conf
+++ b/common/nginx/nginx_internal.conf
@@ -41,7 +41,7 @@ server {
     # backend
     location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
         limit_req zone=limiter burst=50;
-        proxy_pass "http://${API_HOST}:8080";
+        include api_proxy;
 
         # Send actual client IP upstream
         include proxy_params;
@@ -50,7 +50,7 @@ server {
     # rate limit on /api/v3 endpoints
     location ~ ^/api/v3/(post|message|register|image|comment|search) {
         limit_req zone=limiter burst=50 nodelay;
-        proxy_pass "http://${API_HOST}:8080";
+        include api_proxy;
         include proxy_params;
     }
 }
@@ -93,7 +93,7 @@ server {
 
     # backend
     location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
-        proxy_pass "http://${API_HOST}:8080";
+        include api_proxy;
 
         # Send actual client IP upstream
         include proxy_params;

--- a/common/nginx/nginx_internal.conf
+++ b/common/nginx/nginx_internal.conf
@@ -41,7 +41,7 @@ server {
     # backend
     location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
         limit_req zone=limiter burst=50;
-        proxy_pass "http://sublinks:8080";
+        proxy_pass "http://${API_HOST}:8080";
 
         # Send actual client IP upstream
         include proxy_params;
@@ -50,7 +50,7 @@ server {
     # rate limit on /api/v3 endpoints
     location ~ ^/api/v3/(post|message|register|image|comment|search) {
         limit_req zone=limiter burst=50 nodelay;
-        proxy_pass "http://sublinks:8080";
+        proxy_pass "http://${API_HOST}:8080";
         include proxy_params;
     }
 }
@@ -93,10 +93,9 @@ server {
 
     # backend
     location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
-        proxy_pass "http://sublinks:8080";
+        proxy_pass "http://${API_HOST}:8080";
 
         # Send actual client IP upstream
         include proxy_params;
     }
 }
-

--- a/common/nginx/start.sh
+++ b/common/nginx/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Substitute environment variables in the nginx configuration file
+envsubst < /tmp/api_proxy > /etc/nginx/api_proxy
+
+# Start Nginx
+/scripts/start_nginx_certbot.sh

--- a/common/proxy.yml
+++ b/common/proxy.yml
@@ -17,6 +17,7 @@ services:
       USE_LOCAL_CA: 1
       STAGING: 1
       NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE: 1
+      API_HOST: ${API_HOST:-sublinks}
     ports:
       - "80:8080"
       - "443:8443"
@@ -26,7 +27,8 @@ services:
       - letsencrypt:/etc/letsencrypt
     restart: always
     logging: *default-logging
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       ui:
         condition: service_healthy
-

--- a/common/proxy.yml
+++ b/common/proxy.yml
@@ -11,7 +11,9 @@ x-logging: &default-logging
 
 services:
   proxy:
-    image: jonasal/nginx-certbot:4.3.0-nginx1.25.1-alpine
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
     environment:
       CERTBOT_EMAIL: developer@example.com
       USE_LOCAL_CA: 1

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -1,0 +1,33 @@
+version: "3.7"
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "4"
+
+include:
+  - common/services.yml
+  - federation/services.yml
+  - ${UI:-lemmy}-ui/services.yml
+
+services:
+  api:
+    image: busybox
+    # This is a hack since the UI requires the sublinks service to be up
+    # Just spin & wait forever
+    command: sleep infinity
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD", "echo", "up"]
+      start_period: 40s
+      interval: 15s
+      timeout: 10s
+      retries: 10
+    depends_on:
+      maindb:
+        condition: service_healthy
+      queue:
+        condition: service_healthy
+      pictrs: # NOTE: condition is different because of lack of healthcheck
+        condition: service_started

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -10,6 +10,7 @@ include:
   - common/services.yml
   - federation/services.yml
   - ${UI:-lemmy}-ui/services.yml
+  - backend/seeder.yml
 
 services:
   api:

--- a/frontend/services.yml
+++ b/frontend/services.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      sublinks:
+      api:
         condition: service_healthy
       federation:
         condition: service_healthy

--- a/lemmy-ui/services.yml
+++ b/lemmy-ui/services.yml
@@ -21,7 +21,7 @@ services:
     restart: always
     logging: *default-logging
     depends_on:
-      sublinks:
+      api:
         condition: service_healthy
       federation:
         condition: service_healthy

--- a/lemmy-ui/services.yml
+++ b/lemmy-ui/services.yml
@@ -16,10 +16,12 @@ services:
       #- LEMMY_UI_DEBUG=true
       - LEMMY_UI_HOST=0.0.0.0:3000
       - LEMMY_UI_DISABLE_CSP=true
-      - LEMMY_UI_LEMMY_INTERNAL_HOST=sublinks:8080
+      - LEMMY_UI_LEMMY_INTERNAL_HOST=${API_HOST:-sublinks}:8080
       - LEMMY_UI_LEMMY_EXTERNAL_HOST=demo.sublinks.org
     restart: always
     logging: *default-logging
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       api:
         condition: service_healthy
@@ -30,4 +32,3 @@ services:
       interval: 15s
       timeout: 10s
       retries: 10
-


### PR DESCRIPTION
### Added
- Support for running Sublinks API dependencies with `docker-compose.backend.yml`

### Changed
- Renamed `sublinks` service to `api` in `backend/services.yml`
- Updated dependencies in `frontend/services.yml` and `lemmy-ui/services.yml` to depend on `api` service instead of `sublinks` (due to rename)

### NOTE
This PR also allows running Sublinks UI instead of Lemmy UI. Requires the following 2 PRs be merged:

- ~https://github.com/sublinks/sublinks-frontend/pull/112~ (Done)
- https://github.com/sublinks/sublinks-docker/pull/7

However, this PR should still be able to proceed as the default (fallback) is to use the Lemmy UI