### PR TITLE
Fix seeder api error

### DIFF
--- a/common/seeder/job-seeder.js
+++ b/common/seeder/job-seeder.js
@@ -54,6 +54,8 @@ const doesEntityAlreadyExist = async entity => {
     case 'createComment':
       try {
         const commentRes = await apiClient.getComments({
+          sort: 'Hot',
+          type_: 'All',
           post_id: data.post_id
         });
 
@@ -91,7 +93,7 @@ const runInitialSiteSetup = async () => {
 
   await createUser(adminUser);
   const { jwt } = await apiClient.login(adminUser.credentials);
-  await apiClient.setAuth(jwt);
+  apiClient.setAuth(jwt);
 
   if (!isSiteSetUp) {
     await apiClient.createSite(siteData);

--- a/common/seeder/job-seeder.js
+++ b/common/seeder/job-seeder.js
@@ -78,7 +78,11 @@ const createUser = async user => {
 
     if (userRes.errors) {
       console.log(`Creating user with ID ${user.data.id}`);
-      await apiClient.register(user.data);
+      const registerRes = await apiClient.register(user.data);
+
+      if (registerRes.errors) {
+        throw Error(`User registration request failed: ${registerRes.message} -- ${JSON.stringify(registerRes.errors)}`);
+      }
     }
   } catch (e) {
     console.log(`Failed creating user with ID ${user.data.id}`, e);
@@ -96,7 +100,11 @@ const runInitialSiteSetup = async () => {
   apiClient.setAuth(jwt);
 
   if (!isSiteSetUp) {
-    await apiClient.createSite(siteData);
+    const siteRes = await apiClient.createSite(siteData);
+
+    if (siteRes.errors) {
+      throw Error(`Site creation failed: ${siteRes.message} -- ${JSON.stringify(siteRes.errors)}`);
+    }
   }
 
   console.log('Site configuration completed!');
@@ -133,10 +141,12 @@ const insertSeedData = async () => {
         if (data.image_url) {
           const fileRes = await fetch(data.image_url);
           const fileBuffer = Buffer.from(await fileRes.arrayBuffer());
-          const upload = await apiClient.uploadImage({ image: fileBuffer });
+          const uploadRes = await apiClient.uploadImage({ image: fileBuffer });
 
-          if (upload.url) {
-            data.url = upload.url;
+          if (uploadRes.url) {
+            data.url = uploadRes.url;
+          } else if (uploadRes.errors) {
+            console.log(`Failed uploading image for post ${data.id}: ${uploadRes.message} -- ${JSON.stringify(uploadRes.errors)}`);
           }
         }
 

--- a/common/seeder/job-seeder.js
+++ b/common/seeder/job-seeder.js
@@ -183,7 +183,7 @@ const insertSeedData = async () => {
 
         const entityFnRes = await apiClient[type](data);
         if (entityFnRes.errors) {
-          console.log(`Failed to seed entity with ID ${data.id || data.post_id}: ${entityFnRes.message}`);
+          console.log(`Failed to seed entity with ID ${data.id || data.post_id}: ${entityFnRes.message} -- ${JSON.stringify(uploadRes.errors)}`);
         }
       }
     }

--- a/common/seeder/job-seeder.js
+++ b/common/seeder/job-seeder.js
@@ -30,7 +30,7 @@ const waitForApi = async seedFn => {
 };
 
 const doesEntityAlreadyExist = async entity => {
-  const { data, type } = entity;
+  const { creator, data, type } = entity;
 
   switch(type) {
     case 'createCommunity':
@@ -64,6 +64,20 @@ const doesEntityAlreadyExist = async entity => {
         }
 
         return commentRes.comments.some(commentView => commentView.comment.id === data.id);
+      } catch (e) {
+        return false;
+      }
+    case 'likePost':
+      try {
+        const likesRes = await apiClient.listPostLikes({
+          post_id: data.post_id
+        });
+
+        if (Boolean(likesRes.errors)) {
+          return false;
+        }
+
+        return likesRes.post_likes.some(voteView => voteView.creator.id === creator.data.id);
       } catch (e) {
         return false;
       }

--- a/common/seeder/package-lock.json
+++ b/common/seeder/package-lock.json
@@ -8,13 +8,13 @@
       "name": "sublinks-job-seeder",
       "version": "1.0.0",
       "dependencies": {
-        "sublinks-js-client": "^0.0.15"
+        "sublinks-js-client": "^0.0.17"
       }
     },
     "node_modules/sublinks-js-client": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/sublinks-js-client/-/sublinks-js-client-0.0.15.tgz",
-      "integrity": "sha512-oJzllfgDLGwZrIYOvVWgRnnGT2aAFqoXYkYbfo4OT0Y1ElxyUsFyAH3KFwYRFoJ4oPs6VeLfIepjMXfYN5y5Uw=="
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/sublinks-js-client/-/sublinks-js-client-0.0.17.tgz",
+      "integrity": "sha512-OPfvvqdDWD/CGO12bdBcEHUGTIj7Taqu3aV4gOpd9kjV7i/xjoRKLtxyHj/wGfkKIWlwBwOygtOMScIem86r1Q=="
     }
   }
 }

--- a/common/seeder/package-lock.json
+++ b/common/seeder/package-lock.json
@@ -8,13 +8,13 @@
       "name": "sublinks-job-seeder",
       "version": "1.0.0",
       "dependencies": {
-        "sublinks-js-client": "^0.0.13"
+        "sublinks-js-client": "^0.0.15"
       }
     },
     "node_modules/sublinks-js-client": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/sublinks-js-client/-/sublinks-js-client-0.0.13.tgz",
-      "integrity": "sha512-qMqPhVvln0N+lUew/fMQUur2DB3R3yr0fbTxmW2JrNftYL80cRCCapF1L+WfMTDe8agtS4+vaK6VG5M+q6HztQ=="
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/sublinks-js-client/-/sublinks-js-client-0.0.15.tgz",
+      "integrity": "sha512-oJzllfgDLGwZrIYOvVWgRnnGT2aAFqoXYkYbfo4OT0Y1ElxyUsFyAH3KFwYRFoJ4oPs6VeLfIepjMXfYN5y5Uw=="
     }
   }
 }

--- a/common/seeder/package.json
+++ b/common/seeder/package.json
@@ -5,6 +5,6 @@
     "seed": "node ./job-seeder.js"
   },
   "dependencies": {
-    "sublinks-js-client": "^0.0.15"
+    "sublinks-js-client": "^0.0.17"
   }
 }

--- a/common/seeder/package.json
+++ b/common/seeder/package.json
@@ -5,6 +5,6 @@
     "seed": "node ./job-seeder.js"
   },
   "dependencies": {
-    "sublinks-js-client": "^0.0.13"
+    "sublinks-js-client": "^0.0.15"
   }
 }


### PR DESCRIPTION
API client update changes how errors are handled. They're no longer thrown to us, rather `errors` and `message` properties are instead part of the response when something goes wrong.

Currently `errors` mainly/only contains `["error occurred"]` hence why the logging relies more on `message`.

It also introduces some "caching" mechanics to save requests when checking for existing entities.