### PR TITLE
Remove docker-compose configuration for demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ release we will provide sample files for use in a live site.***
 themselves should not be included. Eg:
 
 ```bash
-docker-compose -f docker-compose.demo.yml up [-d]
+docker-compose -f docker-compose.<area>.yml up [-d]
 ```
 
 In the above command, you can run it either as:
 
 ```bash
-docker-compose -f docker-compose.demo.yml up
+docker-compose -f docker-compose.<area>.yml up
 ```
 
 or
 
 ```bash
-docker-compose -f docker-compose.demo.yml up -d
+docker-compose -f docker-compose.<area>.yml up -d
 ```
 
 The `-d` is optional. It means "detach" and will cause the command prompt to
 return almost immediately but the docker images will continue running in the
 background.  If you use this method, you must run
-`docker-compose -f docker-compose.demo.yml down` in order to teardown the
+`docker-compose -f docker-compose.<area>.yml down` in order to teardown the
 environment (NOTE: You can also use `stop` instead of `down` if you only want
 to stop the containers but not actually tear them down. This is useful if you
 plan to bring the containers back up and want their current state to be
@@ -40,9 +40,8 @@ containers they are brought up in a "clean" state)
 
 ## Demo Site
 
-Run `docker-compose -f docker-compose.demo.yml up [-d]`
-OR to run the demo site with the Sublinks UI (currently experimental), run:
-`UI=sublinks docker-compose -f docker-compose.demo.yml up [-d]`
+NOTE: Demo site has been removed for now. We will add it back in once we have
+a more stable version of the site to show off.
 
 ## Frontend Dev
 
@@ -50,9 +49,9 @@ Run `docker-compose -f docker-compose.frontend.yml up [-d]`
 
 ## Backend Dev
 
-Run `docker-compose -f docker-compose.backend.yml up [-d]`
+Run `API_HOST=host.docker.internal docker-compose -f docker-compose.backend.yml up [-d]`
 OR to run the Sublinks UI (currently experimental), run:
-`UI=sublinks docker-compose -f docker-compose.backend.yml up [-d]`
+`UI=sublinks API_HOST=host.docker.internal docker-compose -f docker-compose.backend.yml up [-d]`
 
 ## Federation Dev
 

--- a/backend/services.yml
+++ b/backend/services.yml
@@ -18,7 +18,7 @@ services:
       SUBLINKS_DB_USERNAME: backend
       SUBLINKS_DB_PASSWORD: backend
       SUBLINKS_JWT_SECRET: YouShouldChangeThisItJustNeedsToBe64charactersLongUsingAlphaNum1
-      SUBLINKS_BASE_URL: https://demo.sublinks.org
+      SUBLINKS_BASE_URL: http://host.docker.internal
       SUBLINKS_PICTRS_URL: http://pictrs:8080
       FEDERATION_QUEUE_HOST: queue
       FEDERATION_QUEUE_PORT: 5672

--- a/common/nginx/nginx_internal.conf
+++ b/common/nginx/nginx_internal.conf
@@ -15,7 +15,7 @@ server {
     resolver 127.0.0.11;
 
     # change if needed, this is facing the public web
-    server_name demo.sublinks.org; # certbot_domain:*.sublinks.org
+    server_name host.docker.local; # certbot_domain:*.sublinks.org
     server_tokens off;
 
     # Upload limit, relevant for pictrs
@@ -70,7 +70,7 @@ server {
     ssl_dhparam /etc/letsencrypt/dhparams/dhparam.pem;
 
     # change if needed, this is facing the public web
-    server_name demo.sublinks.org; # certbot_domain:*.sublinks.org
+    server_name host.docker.local; # certbot_domain:*.sublinks.org
 
     # Upload limit, relevant for pictrs
     client_max_body_size 20M;

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,8 +1,0 @@
-version: "3.7"
-
-include:
-  - common/services.yml
-  - backend/services.yml
-  - federation/services.yml
-  - ${UI:-lemmy}-ui/services.yml
-

--- a/lemmy-ui/services.yml
+++ b/lemmy-ui/services.yml
@@ -17,7 +17,7 @@ services:
       - LEMMY_UI_HOST=0.0.0.0:3000
       - LEMMY_UI_DISABLE_CSP=true
       - LEMMY_UI_LEMMY_INTERNAL_HOST=${API_HOST:-api}:8080
-      - LEMMY_UI_LEMMY_EXTERNAL_HOST=demo.sublinks.org
+      - LEMMY_UI_LEMMY_EXTERNAL_HOST=host.docker.internal
     restart: always
     logging: *default-logging
     extra_hosts:

--- a/sublinks-ui/services.yml
+++ b/sublinks-ui/services.yml
@@ -14,7 +14,7 @@ services:
     image: ghcr.io/sublinks/sublinks-frontend:main
     environment:
       - NEXT_PUBLIC_SUBLINKS_API_BASE_URL=api:8080
-      - NEXT_PUBLIC_SUBLINKS_API_BASE_PUBLIC_URL=demo.sublinks.org
+      - NEXT_PUBLIC_SUBLINKS_API_BASE_PUBLIC_URL=host.docker.internal
       - NEXT_PUBLIC_HTTPS_ENABLED=true
     restart: always
     logging: *default-logging


### PR DESCRIPTION
BREAKING CHANGE: Remove demo site docker-compose configuration
- Remove docker-compose.demo.yml as the demo site has been paused during early dev phase
- Update docker-compose commands to use a generic <area> placeholder
- Set API_HOST to host.docker.internal for backend development
- Update SUBLINKS_BASE_URL and LEMMY_UI_LEMMY_EXTERNAL_HOST to use host.docker.internal
- Change server_name in nginx_internal.conf to host.docker.local
- Adjust sublinks-ui and lemmy-ui services to use host.docker.internal for public URLs