### PR TITLE
Remove version specification from multiple docker-compose files

### DIFF
--- a/backend/seeder.yml
+++ b/backend/seeder.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:

--- a/backend/services.yml
+++ b/backend/services.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:

--- a/common/proxy.yml
+++ b/common/proxy.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 volumes:
   letsencrypt:
 

--- a/common/services.yml
+++ b/common/services.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 volumes:
   letsencrypt:
 

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:

--- a/docker-compose.federation.yml
+++ b/docker-compose.federation.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 include:
   - common/services.yml
   - backend/services.yml

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 include:
   - common/services.yml
   - backend/services.yml

--- a/federation/services.yml
+++ b/federation/services.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:

--- a/frontend/services.yml
+++ b/frontend/services.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:

--- a/lemmy-ui/services.yml
+++ b/lemmy-ui/services.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:

--- a/sublinks-ui/services.yml
+++ b/sublinks-ui/services.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:


### PR DESCRIPTION
Removed the version specification "3.7" from the top of various docker-compose and related YAML files across the project to align with the latest practices and recommendations for Docker Compose file versioning. 
This change affects
- backend
- common
- federation
- frontend
- lemmy-ui
- sublinks-ui